### PR TITLE
Add icons "copy" option

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -15,6 +15,7 @@ const defaultConfig = {
   },
   icons: {
     path: 'icons',
+    copy: false,
   },
   styles: {
     path: 'styles',

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,7 @@ module.exports = {
 | `scripts.path` | `{String}` | `scripts` | Path to scripts directory |
 | `scripts.entries` | `{Object}` | `` |  |
 | `icons.path` | `{String}` | `icons` | Path to icons directory |
+| `icons.copy` | `{Boolean}` | `false` | Copy icon files to dist folder |
 | `webpack` | `{Function}` | `null` | Function to extend the use of `webpack` |
 
 #### `source`
@@ -108,6 +109,18 @@ module.exports = {
       app: './app.js',
       polyfills: './polyfills.js',
     },
+  }
+}
+```
+
+#### `icons`
+Generates a stylesheet from SVG files. It's also possible to copy the icon files to the dist folder by setting the `copy` property to `true`.
+```javascript
+// bricks.config.js
+module.exports = {
+  icons: {
+    path: 'icons',
+    copy: false,
   }
 }
 ```

--- a/tasks/icons.js
+++ b/tasks/icons.js
@@ -9,6 +9,8 @@ module.exports = function icons() {
   const src = path.join(config.source, config.icons.path, '**/**.svg');
   const dest = path.join(config.output, config.icons.path);
 
+  const shape = config.icons.copy ? { dest: '.' } : null;
+
   return gulp
     .src(src)
     .pipe(
@@ -18,9 +20,7 @@ module.exports = function icons() {
     )
     .pipe(
       sprite({
-        shape: {
-          dest: '.',
-        },
+        shape,
         mode: {
           symbol: {
             dest: '',


### PR DESCRIPTION
Allows you to provide an optional `copy: true` property in the `icons` object in `bricks.config.js` to copy the icon files to dist